### PR TITLE
Minimal changes on start page steps 2-8 and starting-surrealdb page

### DIFF
--- a/app/snippets/docs/start/index/linux.shell
+++ b/app/snippets/docs/start/index/linux.shell
@@ -1,4 +1,4 @@
-user@localhost % surreal start --log debug memory
+user@localhost % surreal start --log debug memory -p root
 [2022-07-28 15:50:34] INFO  surrealdb::iam Root authentication is disabled
 [2022-07-28 15:50:34] INFO  surrealdb::dbs Database strict mode is disabled
 [2022-07-28 15:50:34] INFO  surrealdb::kvs Starting kvs store in memory

--- a/app/snippets/docs/start/index/step1.bash
+++ b/app/snippets/docs/start/index/step1.bash
@@ -1,5 +1,6 @@
+DATA="INFO FOR DB;"
 curl --request POST \
 	--header 'Content-Type: application/json' \
 	--user "root:root" \
-	--data "INFO FOR DB" \
+	--data "${DATA}" \
 	http://localhost:8000/sql

--- a/app/snippets/docs/start/index/step3.bash
+++ b/app/snippets/docs/start/index/step3.bash
@@ -1,0 +1,10 @@
+DATA="CREATE account SET
+	name = \"ACME Inc\",
+	created_at = time::now();"
+curl -k -L -s --compressed POST \
+	--header 'Content-Type: application/json' \
+	--header 'NS: test' \
+	--header 'DB: test' \
+	--user "root:root" \
+	--data "${DATA}" \
+	http://localhost:8000/sql

--- a/app/snippets/docs/start/index/step3.bash
+++ b/app/snippets/docs/start/index/step3.bash
@@ -1,7 +1,7 @@
 DATA="CREATE account SET
 	name = \"ACME Inc\",
 	created_at = time::now();"
-curl -k -L -s --compressed POST \
+curl -s POST \
 	--header 'Content-Type: application/json' \
 	--header 'NS: test' \
 	--header 'DB: test' \

--- a/app/snippets/docs/start/index/step4.bash
+++ b/app/snippets/docs/start/index/step4.bash
@@ -1,0 +1,14 @@
+DATA="CREATE author:john SET
+	name.first = \"John\",
+	name.last = \"Adams\",
+	name.full = string::join(" ", name.first, name.last),
+	age = 29,
+	admin = true,
+	signup_at = time::now();"
+curl -k -L -s --compressed POST \
+	--header "Content-Type: application/json" \
+	--header "NS: test" \
+	--header "DB: test" \
+	--user "root:root" \
+	--data "${DATA}" \
+	http://localhost:8000/sql

--- a/app/snippets/docs/start/index/step4.bash
+++ b/app/snippets/docs/start/index/step4.bash
@@ -5,7 +5,7 @@ DATA="CREATE author:john SET
 	age = 29,
 	admin = true,
 	signup_at = time::now();"
-curl -k -L -s --compressed POST \
+curl -s POST \
 	--header "Content-Type: application/json" \
 	--header "NS: test" \
 	--header "DB: test" \

--- a/app/snippets/docs/start/index/step5.bash
+++ b/app/snippets/docs/start/index/step5.bash
@@ -1,0 +1,13 @@
+DATA="CREATE article SET
+	created_at = time::now(),
+	author = author:john,
+	title = \"Lorem ipsum dolor\",
+	text = \"Donec eleifend, nunc vitae commodo accumsan, mauris est fringilla.\",
+	account = (SELECT id FROM account WHERE name = \"ACME Inc\" LIMIT 1);"
+curl -k -L -s --compressed POST \
+	--header "Content-Type: application/json" \
+	--header "NS: test" \
+	--header "DB: test" \
+	--user "root:root" \
+	--data "${DATA}" \
+	http://localhost:8000/sql

--- a/app/snippets/docs/start/index/step5.bash
+++ b/app/snippets/docs/start/index/step5.bash
@@ -4,7 +4,7 @@ DATA="CREATE article SET
 	title = \"Lorem ipsum dolor\",
 	text = \"Donec eleifend, nunc vitae commodo accumsan, mauris est fringilla.\",
 	account = (SELECT id FROM account WHERE name = \"ACME Inc\" LIMIT 1);"
-curl -k -L -s --compressed POST \
+curl -s POST \
 	--header "Content-Type: application/json" \
 	--header "NS: test" \
 	--header "DB: test" \

--- a/app/snippets/docs/start/index/step6.bash
+++ b/app/snippets/docs/start/index/step6.bash
@@ -1,5 +1,5 @@
-DATA="INFO FOR DB;"
-curl --request POST \
+DATA="SELECT * FROM article;"
+curl -k -L -s --compressed POST \
 	--header "Content-Type: application/json" \
 	--header "NS: test" \
 	--header "DB: test" \

--- a/app/snippets/docs/start/index/step6.bash
+++ b/app/snippets/docs/start/index/step6.bash
@@ -1,5 +1,5 @@
 DATA="SELECT * FROM article;"
-curl -k -L -s --compressed POST \
+curl -s POST \
 	--header "Content-Type: application/json" \
 	--header "NS: test" \
 	--header "DB: test" \

--- a/app/snippets/docs/start/index/step7.bash
+++ b/app/snippets/docs/start/index/step7.bash
@@ -1,5 +1,5 @@
-DATA="INFO FOR DB;"
-curl --request POST \
+DATA="SELECT * FROM article, account;"
+curl -k -L -s --compressed POST \
 	--header "Content-Type: application/json" \
 	--header "NS: test" \
 	--header "DB: test" \

--- a/app/snippets/docs/start/index/step7.bash
+++ b/app/snippets/docs/start/index/step7.bash
@@ -1,5 +1,5 @@
 DATA="SELECT * FROM article, account;"
-curl -k -L -s --compressed POST \
+curl -s POST \
 	--header "Content-Type: application/json" \
 	--header "NS: test" \
 	--header "DB: test" \

--- a/app/snippets/docs/start/index/step8.bash
+++ b/app/snippets/docs/start/index/step8.bash
@@ -1,5 +1,5 @@
-DATA="INFO FOR DB;"
-curl --request POST \
+DATA="SELECT * FROM article WHERE author.age < 30 FETCH author, account;"
+curl -k -L -s --compressed POST \
 	--header "Content-Type: application/json" \
 	--header "NS: test" \
 	--header "DB: test" \

--- a/app/snippets/docs/start/index/step8.bash
+++ b/app/snippets/docs/start/index/step8.bash
@@ -1,5 +1,5 @@
 DATA="SELECT * FROM article WHERE author.age < 30 FETCH author, account;"
-curl -k -L -s --compressed POST \
+curl -s POST \
 	--header "Content-Type: application/json" \
 	--header "NS: test" \
 	--header "DB: test" \

--- a/app/snippets/docs/start/index/windows.shell
+++ b/app/snippets/docs/start/index/windows.shell
@@ -1,4 +1,4 @@
-PS C:\> surreal.exe start --log debug memory
+PS C:\> surreal.exe start --log debug memory -p root
 [2022-07-28 15:50:34] INFO  surrealdb::iam Root authentication is disabled
 [2022-07-28 15:50:34] INFO  surrealdb::dbs Database strict mode is disabled
 [2022-07-28 15:50:34] INFO  surrealdb::kvs Starting kvs store in memory

--- a/app/templates/docs/start/index.hbs
+++ b/app/templates/docs/start/index.hbs
@@ -38,16 +38,19 @@
 	<p>By default, SurrealDB doesn't need to have tables or fields defined before inserting data. Instead the database can be queried in schemaless mode, and tables are created ad hoc. In this guide, we will be running all queries in schemaless mode.</p>
 	<codes vertical>
 		<Code @name="docs/start/index/step3.sql" text="SQL" />
+		<Code @name="docs/start/index/step3.bash" text="Command line" />
 		<Code @name="docs/start/index/step3.json" text="Output" />
 	</codes>
 	<p>In the response above, we can see that the 'author' record has been created, and a random ID has been generated for this record. In SurrealDB every record can be created and accessed directly by its ID. In the following query, we will create a record, but will use a specific ID.</p>
 	<codes vertical>
 		<Code @name="docs/start/index/step4.sql" text="SQL" />
+		<Code @name="docs/start/index/step4.bash" text="Command line" />
 		<Code @name="docs/start/index/step4.json" text="Output" />
 	</codes>
 	<p>Let's now create a blog article record, which links to the author and account tables. In the following example we link to the author record directly by its ID, and we link to the account record with a subquery which searches using the 'name' field.</p>
 	<codes vertical>
 		<Code @name="docs/start/index/step5.sql" text="SQL" />
+		<Code @name="docs/start/index/step5.bash" text="Command line" />
 		<Code @name="docs/start/index/step5.json" text="Output" />
 	</codes>
 </Layout::Text>
@@ -59,16 +62,19 @@
 	<p>The querying functionality in SurrealDB works similarly to a traditional relational SQL database, but with many of the added benefits of a NoSQL database. To retrieve data, we will use a <code>SELECT</code> query.</p>
 	<codes vertical>
 		<Code @name="docs/start/index/step6.sql" text="SQL" />
+		<Code @name="docs/start/index/step6.bash" text="Command line" />
 		<Code @name="docs/start/index/step6.json" text="Output" />
 	</codes>
 	<p>In SurrealDB we can retrieve data from multiple different tables or records at once. In the example below we'll retrieve data from both the 'article' and the 'account' table in one query..</p>
 	<codes vertical>
 		<Code @name="docs/start/index/step7.sql" text="SQL" />
+		<Code @name="docs/start/index/step7.bash" text="Command line" />
 		<Code @name="docs/start/index/step7.json" text="Output" />
 	</codes>
 	<p>One of the most powerful functions in SurrealDB is the related records and graph connections. Instead of pulling data from multiple tables and merging that data together, SurrealDB allows you to traverse related records efficiently without needing to use JOINs. In this following example, we will fetch the blog article, but are going to filter records based on the field in a remote record, and then pull the remote record data into the final response output.</p>
 	<codes vertical>
 		<Code @name="docs/start/index/step8.sql" text="SQL" />
+		<Code @name="docs/start/index/step8.bash" text="Command line" />
 		<Code @name="docs/start/index/step8.json" text="Output" />
 	</codes>
 </Layout::Text>

--- a/app/templates/docs/start/installation.hbs
+++ b/app/templates/docs/start/installation.hbs
@@ -74,22 +74,22 @@
 
 		Fetching the latest database version...
 		Fetching the host system architecture...
-		Installing surreal-v1.0.0-beta.1 for darwin-arm64...
+		Installing surreal-v1.0.0-beta.5 for linux-amd64...
 
 		SurrealDB successfully installed in:
-		  /Users/tobie/.surrealdb/surreal
+		/home/tobie/.surrealdb/surreal
 
 		To ensure that surreal is in your $PATH run:
-		  PATH=/Users/tobie/.surrealdb:$PATH
+		PATH=/home/tobie/.surrealdb:$PATH
 		Or to move the binary to /usr/local/bin run:
-		  sudo mv /Users/tobie/.surrealdb/surreal /usr/local/bin
+		sudo mv /home/tobie/.surrealdb/surreal /usr/local/bin
 
 		To see the command-line options run:
-		  surreal help
+		surreal help
 		To start an in-memory database server run:
-		  surreal -vvv start memory
+		surreal start --log-level debug --path memory
 		For help with getting started visit:
-		  https://surrealdb.com/docs
+		https://surrealdb.com/docs
 
 	</Code>
 
@@ -134,7 +134,7 @@
 
 		Fetching the latest database version...
 		Fetching the host system architecture...
-		Installing surreal-v1.0.0-beta.1 for windows-amd64...
+		Installing surreal-v1.0.0-beta.5 for windows-amd64...
 
 		SurrealDB successfully installed in:
 		  C:\Users\Tobie\Documents\surreal.exe

--- a/app/templates/docs/start/starting-surrealdb.hbs
+++ b/app/templates/docs/start/starting-surrealdb.hbs
@@ -105,6 +105,51 @@
 <Layout::Gap small />
 
 <Layout::Text text-l text-f>
+
+	<h3>Starting a multi-node distributed database with persistence storage</h3>
+
+	<p>same steps as above, but to run it with persistence you can give it a persistent cluster tag name <Ascua::Prism::Inline @language="bash" @code="--tag surrealdb-kv" /> on run TiKV command</p>
+
+	<Code @name="docs-start-starting-step10.shell">
+		user@localhost % tiup playground --tag surrealdb-kv --mode tikv-slim --pd 3 --kv 3
+		Using the version v6.1.0 for version constraint "".
+
+		If you'd like to use a TiDB version other than v6.1.0, cancel and retry with the following arguments:
+			Specify version manually:   tiup playground version
+			Specify version range:      tiup playground ^5
+			The nightly version:        tiup playground nightly
+
+		Playground Bootstrapping...
+		Start pd instance:v6.1.0
+		Start pd instance:v6.1.0
+		Start pd instance:v6.1.0
+		Start tikv instance:v6.1.0
+		Start tikv instance:v6.1.0
+		Start tikv instance:v6.1.0
+		PD client endpoints: [127.0.0.1:2379 127.0.0.1:2382 127.0.0.1:2384]
+		To view the Prometheus: http://127.0.0.1:9090
+		To view the Grafana: http://127.0.0.1:3000
+	</Code>
+
+	<p>Once TiKV is up and running, we can start a SurrealDB server instance, specifying the TiKV cluster endpoint as the backing data store.</p>
+
+	<Code @name="docs-start-starting-step11.shell">
+		user@localhost % surreal start --log trace --user root --pass root tikv://127.0.0.1:2379
+		[2022-08-03 14:55:54] INFO  surrealdb::iam Root authentication is enabled
+		[2022-08-03 14:55:54] INFO  surrealdb::dbs Database strict mode is disabled
+		[2022-08-03 14:55:54] INFO  surrealdb::kvs Connecting to kvs store at tikv://127.0.0.1:2379
+		[2022-08-03 14:55:54] INFO  surrealdb::kvs Connected to kvs store at tikv://127.0.0.1:2379
+		[2022-08-03 14:55:54] INFO  surrealdb::net Starting web server on 0.0.0.0:8000
+		[2022-08-03 14:55:54] INFO  surrealdb::net Started web server on 0.0.0.0:8000
+	</Code>
+
+	<p>TiKV data will be stored in <Ascua::Prism::Inline @language="bash" @code="/home/tobie/.tiup/data/surrealdb-kv" />, macos in <Ascua::Prism::Inline @language="bash" @code="/Users/tobie/.tiup/data/surrealdb-kv" /></p>
+
+</Layout::Text>
+
+<Layout::Gap small />
+
+<Layout::Text text-l text-f>
 	<h3>Next steps</h3>
 	<p>Congratulations, you’ve now successfully started SurrealDB! You are now ready to start inserting data and performing queries against SurrealDB. Take a look at the next chapter to get started with querying SurrealDB.</p>
 </Layout::Text>


### PR DESCRIPTION
- replaced `curl -k -L -s --compressed`with `curl -s`. we don't need --compressed anymore in surreal-v1.0.0-beta.5
- added multi-node distributed database with persistence storage notes