### PR TITLE
Fix description for db.let function in js docs

### DIFF
--- a/app/templates/docs/integration/libraries/javascript.hbs
+++ b/app/templates/docs/integration/libraries/javascript.hbs
@@ -468,7 +468,7 @@
 
 	<Layout::Text text-l text-f>
 		<h3><Ascua::Prism::Inline @language="js" @code="db.let(key, val)" /></h3>
-		<p>Switch to a specific namespace and database.</p>
+		<p>Assigns a value as a parameter for this connection.</p>
 		<Layout::Table>
 			<table>
 				<thead>


### PR DESCRIPTION
The description for db.let function was the same as db.use