### PR TITLE
Fix string cast description

### DIFF
--- a/app/templates/docs/surrealql/datamodel/casting.hbs
+++ b/app/templates/docs/surrealql/datamodel/casting.hbs
@@ -206,7 +206,7 @@
 
 	<Layout::Text text-l text-f>
 		<h3><code>&lt;string&gt;</code></h3>
-		<p>The <code>&lt;string&gt;</code> casting function converts a value into an infinite precision decimal number.</p>
+		<p>The <code>&lt;string&gt;</code> casting function converts a value into a string.</p>
 		<codes vertical>
 			<Code @name="docs/datamodel/casting/string-input-1.sql" />
 			<Code @name="docs-datamodel-casting-string-result-1.txt">


### PR DESCRIPTION
In the casting section of the docs, The description for casting strings  describe casting for decimal values instead of string.