### PR TITLE
Fix deno run command

### DIFF
--- a/app/templates/docs/integration/libraries/deno.hbs
+++ b/app/templates/docs/integration/libraries/deno.hbs
@@ -12,7 +12,7 @@
 	<Code @name="docs/integration/libraries/deno/basic.js" />
 	<p>Then run your app from the command line with:</p>
 	<Code @name="docs-integration-libraries-deno-basic-run.bash">
-		deno --allow-net=127.0.0.1:8000 mod.ts
+		deno run --allow-net=127.0.0.1:8000 mod.ts
 	</Code>
 </Layout::Text>
 


### PR DESCRIPTION
Command wasn't correct:

```
$ deno --allow-net=127.0.0.1:8000 mod.ts
error: Found argument '--allow-net' which wasn't expected, or isn't valid in this context

        If you tried to supply `--allow-net` as a value rather than a flag, use `-- --allow-net`

USAGE:
    deno [OPTIONS] [SUBCOMMAND]

For more information try --help
````

It should be:

```
$ deno run --allow-net=127.0.0.1:8000 mod.ts 
```