### PR TITLE
rename Angular

### DIFF
--- a/app/templates/docs/index.hbs
+++ b/app/templates/docs/index.hbs
@@ -150,7 +150,7 @@
 	</LinkTo>
 	<LinkTo @route="docs.integration.libraries.angularjs">
 		<Layout::Boxes::Item mini hover faded>
-			<h4><i class="fab fa-angular font-30 m-r-10"></i> Angular.js</h4>
+			<h4><i class="fab fa-angular font-30 m-r-10"></i> Angular</h4>
 		</Layout::Boxes::Item>
 	</LinkTo>
 	<LinkTo @route="docs.integration.libraries.vuejs">

--- a/app/templates/docs/integration/libraries/angularjs.hbs
+++ b/app/templates/docs/integration/libraries/angularjs.hbs
@@ -1,6 +1,6 @@
 <Layout::Text text-l text-f>
 	<h5><i class="fas fa-arrow-left"></i> &nbsp; <Link @link="docs.integration.libraries">Back</Link></h5>
-	<h2><i class="fab fa-angular font-35 m-r-10"></i> Angular.js driver for <img inline src="/static/img/text.svg" alt="SurrealDB" /></h2>
+	<h2><i class="fab fa-angular font-35 m-r-10"></i> Angular driver for <img inline src="/static/img/text.svg" alt="SurrealDB" /></h2>
 	<p>This library has not been released yet. We hope to release this soon.</p>
 	<p>To get started with connecting to SurrealDB from Apollo GraphQL, use the <Link @link="docs.integration.libraries.javascript">JavaScript</Link> library.</p>
 </Layout::Text>

--- a/app/templates/docs/integration/libraries/index.hbs
+++ b/app/templates/docs/integration/libraries/index.hbs
@@ -110,7 +110,7 @@
 	</LinkTo>
 	<LinkTo @route="docs.integration.libraries.angularjs">
 		<Layout::Boxes::Item mini hover faded>
-			<h4><i class="fab fa-angular font-30 m-r-10"></i> Angular.js</h4>
+			<h4><i class="fab fa-angular font-30 m-r-10"></i> Angular</h4>
 		</Layout::Boxes::Item>
 	</LinkTo>
 	<LinkTo @route="docs.integration.libraries.vuejs">

--- a/app/templates/features.hbs
+++ b/app/templates/features.hbs
@@ -1006,10 +1006,10 @@
 				<block>
 					<h4 flex row middle>
 						<i class="fab fa-angular font-30 m-r-10"></i>
-						Angular.js
+						Angular
 						<l pink>Future</l>
 					</h4>
-					<p>A real-time, live-updating library for Angular.js, with authentication, model definition, embedded types, and remote fetching.</p>
+					<p>A real-time, live-updating library for Angular, with authentication, model definition, embedded types, and remote fetching.</p>
 				</block>
 				<block>
 					<h4 flex row middle>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -483,7 +483,7 @@
 
 	<Layout::Gap small />
 
-	<Layout::Text @title="Javascript framework connectors" @text="In addition to the client libraries for the popular languages, SurrealDB maintains database client connectors for some of the popular Javascript frameworks, including Angular.js, and Ember.js. These connectors support real-time data subscriptions and notifications using a binary protocol over a WebSocket connection, enabling advanced application functionality and awesome performance." />
+	<Layout::Text @title="Javascript framework connectors" @text="In addition to the client libraries for the popular languages, SurrealDB maintains database client connectors for some of the popular Javascript frameworks, including Angular, and Ember.js. These connectors support real-time data subscriptions and notifications using a binary protocol over a WebSocket connection, enabling advanced application functionality and awesome performance." />
 
 	<Layout::Gap small />
 
@@ -505,7 +505,7 @@
 		<block>
 			<h4 flex row middle>
 				<i class="fab fa-angular font-30 m-r-10"></i>
-				Angular.js
+				Angular
 				<l pink>Coming soon</l>
 			</h4>
 			<Code @name="index/library/angular.bash" />

--- a/app/templates/usecase/jamstack.hbs
+++ b/app/templates/usecase/jamstack.hbs
@@ -27,7 +27,7 @@
 
 <Layout::Gap small />
 
-<Layout::Text @title="Javascript framework connectors" @text="In addition to the client libraries for the popular languages, SurrealDB maintains database client connectors for some of the popular Javascript frameworks, including Angular.js, and Ember.js. These connectors support real-time data subscriptions and notifications using a binary protocol over a WebSocket connection, enabling advanced application functionality and awesome performance." />
+<Layout::Text @title="Javascript framework connectors" @text="In addition to the client libraries for the popular languages, SurrealDB maintains database client connectors for some of the popular Javascript frameworks, including Angular, and Ember.js. These connectors support real-time data subscriptions and notifications using a binary protocol over a WebSocket connection, enabling advanced application functionality and awesome performance." />
 
 <Layout::Gap small />
 
@@ -49,7 +49,7 @@
 	<block>
 		<h4 flex row middle>
 			<i class="fab fa-angular font-30 m-r-10"></i>
-			Angular.js
+			Angular
 			<l pink>Coming soon</l>
 		</h4>
 		<Code @name="index/library/angular.bash" />

--- a/app/templates/usecase/serverless.hbs
+++ b/app/templates/usecase/serverless.hbs
@@ -30,7 +30,7 @@
 
 <Layout::Gap small />
 
-<Layout::Text @title="Javascript framework connectors" @text="In addition to the client libraries for the popular languages, SurrealDB maintains database client connectors for some of the popular Javascript frameworks, including Angular.js, and Ember.js. These connectors support real-time data subscriptions and notifications using a binary protocol over a WebSocket connection, enabling advanced application functionality and awesome performance." />
+<Layout::Text @title="Javascript framework connectors" @text="In addition to the client libraries for the popular languages, SurrealDB maintains database client connectors for some of the popular Javascript frameworks, including Angular, and Ember.js. These connectors support real-time data subscriptions and notifications using a binary protocol over a WebSocket connection, enabling advanced application functionality and awesome performance." />
 
 <Layout::Gap small />
 
@@ -52,7 +52,7 @@
 	<block>
 		<h4 flex row middle>
 			<i class="fab fa-angular font-30 m-r-10"></i>
-			Angular.js
+			Angular
 			<l pink>Coming soon</l>
 		</h4>
 		<Code @name="index/library/angular.bash" />


### PR DESCRIPTION
To avoid confusion I changed "Angular.js" to "Angular" as "Angular.js" is deprecated.

https://angular.io/guide/ajs-quick-reference#angularjs-to-angular-concepts-quick-reference