### PR TITLE
Replaced "Content-Type" in API docs with "Accept"

### DIFF
--- a/app/templates/docs/integration/http.hbs
+++ b/app/templates/docs/integration/http.hbs
@@ -114,7 +114,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>
@@ -135,7 +135,7 @@
 					 -u "root:root" \
 					 -H "NS: myapplication" \
 					 -H "DB: myapplication" \
-					 -H "Content-Type: application/json" \
+					 -H "Accept: application/json" \
 					 -d "SELECT * FROM person WHERE age > 18" \
 					 http://localhost:8000/sql
 			</Code>
@@ -186,7 +186,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>
@@ -231,7 +231,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>
@@ -275,7 +275,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>
@@ -319,7 +319,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>
@@ -364,7 +364,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>
@@ -409,7 +409,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>
@@ -454,7 +454,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>
@@ -498,7 +498,7 @@
 						<td>Sets the root, namespace, database, or scope authentication data</td>
 					</tr>
 					<tr>
-						<td><code>Content-Type</code></td>
+						<td><code>Accept</code></td>
 						<td>Sets the desired content-type of the response</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
Using the example command as previously written does not work. As far as I can tell this would be correct documentation, but not fully sure. I do know the curl command works now though.