### PR TITLE
docs: update deno example code to be evergreen

### DIFF
--- a/app/snippets/docs/integration/libraries/deno/basic.js
+++ b/app/snippets/docs/integration/libraries/deno/basic.js
@@ -1,11 +1,9 @@
-import Surreal from "https://deno.land/x/surrealdb@v0.2.0/mod.ts";
+import Surreal from "https://deno.land/x/surrealdb/mod.ts";
 
 const db = new Surreal('http://127.0.0.1:8000/rpc');
 
 async function main() {
-
 	try {
-
 		// Signin as a namespace, database, or root user
 		await db.signin({
 			user: 'root',
@@ -40,11 +38,8 @@ async function main() {
 		});
 
 	} catch (e) {
-
 		console.error('ERROR', e);
-
 	}
-
 }
 
 main();


### PR DESCRIPTION
The current code is three versions out of date. We can simply choose to not pin the version to make sure we do not need to update this every time the library is updated. I've also removed strange and unnecessary spaces.