### PR TITLE
Add explicit npx to run ember

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ tests:
 .PHONY: serve
 serve:
 	@echo "Serve..."
-	FASTBOOT_DISABLED=true ember serve
+	FASTBOOT_DISABLED=true npx ember serve
 
 .PHONY: build
 build:


### PR DESCRIPTION
Adding npx explicitly to start ember serve (in case global install failed/terminal hasnt reloaded)