### PR TITLE
Correct `GROUP BY` -> `GROUP` clause for `count()` docs

### DIFF
--- a/app/templates/docs/surrealql/functions/count.hbs
+++ b/app/templates/docs/surrealql/functions/count.hbs
@@ -84,7 +84,7 @@
 				4
 			</Code>
 		</codes>
-		<p>The following examples show this function being used in a <Link @link="docs.surrealql.statements.select"><code>SELECT</code></Link> statement with a <code>GROUP BY</code> clause:</p>
+		<p>The following examples show this function being used in a <Link @link="docs.surrealql.statements.select"><code>SELECT</code></Link> statement with a <code>GROUP</code> clause:</p>
 		<codes vertical>
 			<Code @name="docs-surrealql-functions-count-input-5.surql">
 				SELECT count() FROM [{ age: 33 }, { age: 45 }, { age: 39 }] GROUP ALL;


### PR DESCRIPTION
Correcting an outdated string that was referring to the statment for grouping all rows in one as "group by all" instead of the method "group all", of the new version.