### PR TITLE
Add groovy to supported languages

### DIFF
--- a/app/instance-initializers/marked.js
+++ b/app/instance-initializers/marked.js
@@ -49,6 +49,8 @@ export default {
 					return Prism.highlight(code, Prism.languages.toml, 'toml');
 				case 'yaml':
 					return Prism.highlight(code, Prism.languages.yaml, 'yaml');
+				case 'groovy':
+					return Prism.highlight(code, Prism.languages.groovy, 'groovy');
 				default:
 					return code;
 				}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -21,6 +21,7 @@ module.exports = function (defaults) {
 				'toml',
 				'sql',
 				'yaml',
+				'groovy',
 			],
 			copyToClipboard: true,
 		},


### PR DESCRIPTION
This change adds support for the groovy programming language to Prism Code blocks