### PR TITLE
Replace deprecated method

### DIFF
--- a/app/snippets/docs/integration/libraries/nodejs/basic.js
+++ b/app/snippets/docs/integration/libraries/nodejs/basic.js
@@ -23,7 +23,7 @@ async function main() {
 				last: 'Morgan Hitchcock',
 			},
 			marketing: true,
-			identifier: Math.random().toString(36).substr(2, 10),
+			identifier: Math.random().toString(36).slice(2, 12),
 		});
 
 		// Update a person record with a specific id


### PR DESCRIPTION
Method substr is deprecated now. I replaced it on its equivalent - slice. Their execution result is the same

Math.random().toString(36).substr(2, 10); // '7u98ksx1u8'
Math.random().toString(36).slice(2, 12); //  'wp1lnmupfa'

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr