### PR TITLE
Remove redundant params in java docs

### DIFF
--- a/app/templates/docs/integration/libraries/java.hbs
+++ b/app/templates/docs/integration/libraries/java.hbs
@@ -133,7 +133,7 @@
 			<td>
 				<a href="#signup">
 					<Ascua::Prism::Inline @language="java"
-										  @code="driver.signUp(namespace, database, scope, email, password, marketing, tags)" />
+										  @code="driver.signUp(namespace, database, scope, email, password)" />
 				</a>
 			</td>
 			<td>


### PR DESCRIPTION
Removing 2 params that we dont want in the API and are making the layout too large