### PR TITLE
Docs - Correct semantics of the time::round function.

### DIFF
--- a/app/templates/docs/surrealql/functions/time.hbs
+++ b/app/templates/docs/surrealql/functions/time.hbs
@@ -99,7 +99,7 @@
 						<code>time::round()</code>
 					</a>
 				</td>
-				<td>Rounds a datetime up by a specific duration</td>
+				<td>Rounds a datetime to the nearest multiple of a specific duration</td>
 			</tr>
 			<tr>
 				<td>


### PR DESCRIPTION
Addresses https://github.com/surrealdb/surrealdb/issues/1973