### PR TITLE
Make header sticky on website

### DIFF
--- a/app/styles/components/header.scss
+++ b/app/styles/components/header.scss
@@ -1,10 +1,14 @@
 header {
-
-	z-index:10;
-	width:100%;
-	display:block;
-	position:relative;
-	background-color:transparent;
+		width: 100%;
+		display: block;
+		position: sticky;
+		left: 0;
+		right: 0;
+		top: 0;
+		z-index: 50;
+		background-color: transparent;
+		backdrop-filter: blur(20px);
+		height: 5rem;
 
 	@include media(max-width-1301) {
 		top:0;
@@ -19,10 +23,10 @@ header {
 
 	content {
 
-		display:flex;
-		padding:30px 0;
-		flex-direction:row;
-		justify-content:space-between;
+		display: flex;
+		padding: 0px 0;
+		flex-direction: row;
+		justify-content: space-between;
 
 		@include media(max-width-1301) {
 			padding-top:20px;

--- a/app/styles/components/header.scss
+++ b/app/styles/components/header.scss
@@ -8,7 +8,7 @@ header {
 		z-index: 50;
 		background-color: transparent;
 		backdrop-filter: blur(20px);
-		height: 5rem;
+		height: 6rem;
 
 	@include media(max-width-1301) {
 		top:0;

--- a/app/styles/components/header.scss
+++ b/app/styles/components/header.scss
@@ -18,7 +18,7 @@ header {
 		-webkit-backdrop-filter:blur(10px);
 		-moz-backdrop-filter:blur(10px);
 		-ms-backdrop-filter:blur(10px);
-		backdrop-filter:blur(10px);
+		backdrop-filter:blur(20px);
 	}
 
 	content {
@@ -29,7 +29,7 @@ header {
 		justify-content: space-between;
 
 		@include media(max-width-1301) {
-			padding-top:20px;
+			padding-top:14px;
 		}
 
 		> div {


### PR DESCRIPTION
This PR keeps the header in view while scrolling through the content on all pages. Allowing users to navigate better and have access to more nav options without scrolling to the top of the page. 

Before:
<img width="1466" alt="Screenshot 2023-05-23 at 11 37 17" src="https://github.com/surrealdb/www.surrealdb.com/assets/35943047/1b37d296-afcf-4b5a-9613-fde5e3234c89">


After: 
<img width="1466" alt="Screenshot 2023-05-23 at 11 31 45" src="https://github.com/surrealdb/www.surrealdb.com/assets/35943047/a90b4fe3-47d5-4538-b53e-acf2af121adf">