### PR TITLE
Add exmaples of filtering based on graph edge properties

### DIFF
--- a/app/snippets/docs/surrealql/statements/select/expr.surql
+++ b/app/snippets/docs/surrealql/statements/select/expr.surql
@@ -10,6 +10,9 @@ SELECT addresses[WHERE active = true] FROM customer;
 -- Select a remote field from connected out graph edges
 SELECT ->like->friend.name AS friends FROM person:tobie;
 
+-- Select a record that matches a graph pattern
+SELECT * FROM person WHERE ->(reaction WHERE type='celebrate')->post;
+
 -- Use mathematical calculations in a select expression
 SELECT ( ( celsius * 2 ) + 30 ) AS fahrenheit FROM temperatue;
 

--- a/app/snippets/docs/surrealql/statements/select/expr.surql
+++ b/app/snippets/docs/surrealql/statements/select/expr.surql
@@ -10,7 +10,7 @@ SELECT addresses[WHERE active = true] FROM customer;
 -- Select a remote field from connected out graph edges
 SELECT ->like->friend.name AS friends FROM person:tobie;
 
--- Select a record that matches a graph pattern
+-- Select a person who has reacted to a post using a celebration
 SELECT * FROM person WHERE ->(reaction WHERE type='celebrate')->post;
 
 -- Use mathematical calculations in a select expression

--- a/app/snippets/docs/surrealql/statements/select/where.surql
+++ b/app/snippets/docs/surrealql/statements/select/where.surql
@@ -4,5 +4,8 @@ SELECT * FROM article WHERE published = true;
 -- Conditional filtering based on graph edges
 SELECT * FROM profile WHERE count(->experience->organisation) > 3;
 
+-- Conditional filtering based on graph edge properties
+SELECT * FROM person WHERE ->(reaction WHERE type='celebrate')->post;
+
 -- Conditional filtering with boolean logic
 SELECT * FROM user WHERE (admin AND active) OR owner = true;


### PR DESCRIPTION
Add an example of using graph edge property filtering.

Query test:
```
test/test> create post content {details: 'blaaaa'}
[{ details: 'blaaaa', id: post:bo0weixeus9cibogw1w0 }]

test/test> relate person:one->reaction->post:bo0weixeus9cibogw1w0 content {type: 'celebrate'}
[{ id: reaction:izzaunzjrxqnyybpob4v, in: person:one, out: post:bo0weixeus9cibogw1w0, type: 'celebrate' }]

test/test> SELECT * FROM person WHERE ->(reaction WHERE type='celebrate')->post

[{ id: person:one, name: 'one' }]
```