### PR TITLE
Corrected Windows Installation Instructions

### DIFF
--- a/app/templates/docs/installation/windows.hbs
+++ b/app/templates/docs/installation/windows.hbs
@@ -34,10 +34,10 @@
 
 	<h4>Checking SurrealDB</h4>
 
-	<p>Once installed, you can run the SurrealDB command-line tool by using the <code>surreal.exe</code> command. To check whether the install was successful run the following command in your terminal.</p>
+	<p>Once installed, you can run the SurrealDB command-line tool by using the <code>surreal</code> command. To check whether the installation was successful run the following command in your terminal.</p>
 
 	<Code @name="docs-installation-windows-script-test.shell">
-		PS C:\> C:\Program Files\SurrealDB\surreal.exe help
+		PS C:\> surreal help
 	</Code>
 
 	<p>The result should look similar to the output below, confirming that the SurrealDB command-line tool was installed successfully.</p>


### PR DESCRIPTION
Updated windows.hbs to remove "C:\Program Files" path from commands and use the surreal command which works fine on Windows.