### PR TITLE
Correct syntax, fix syntax highlighting, and link

### DIFF
--- a/app/snippets/docs/surrealql/statements/define/field/array-assert-field.surql
+++ b/app/snippets/docs/surrealql/statements/define/field/array-assert-field.surql
@@ -1,4 +1,4 @@
-DEFINE FIELD resource on acl TYPE record 
+DEFINE FIELD resource ON TABLE acl TYPE record (resource)
   ASSERT $value != NONE;
 DEFINE FIELD user ON TABLE acl TYPE record (user)
   ASSERT $value != NONE;

--- a/app/snippets/docs/surrealql/statements/define/field/array-assert-field.surql
+++ b/app/snippets/docs/surrealql/statements/define/field/array-assert-field.surql
@@ -1,6 +1,6 @@
 DEFINE FIELD resource ON TABLE acl TYPE record(resource)
   ASSERT $value != NONE;
-DEFINE FIELD user ON TABLE acl TYPE record (user)
+DEFINE FIELD user ON TABLE acl TYPE record(user)
   ASSERT $value != NONE;
 
 -- A user can have multiple permissions on a acl

--- a/app/snippets/docs/surrealql/statements/define/field/array-assert-field.surql
+++ b/app/snippets/docs/surrealql/statements/define/field/array-assert-field.surql
@@ -1,4 +1,4 @@
-DEFINE FIELD resource ON TABLE acl TYPE record (resource)
+DEFINE FIELD resource ON TABLE acl TYPE record(resource)
   ASSERT $value != NONE;
 DEFINE FIELD user ON TABLE acl TYPE record (user)
   ASSERT $value != NONE;

--- a/app/snippets/docs/surrealql/statements/select/group.surql
+++ b/app/snippets/docs/surrealql/statements/select/group.surql
@@ -11,7 +11,7 @@ SELECT gender, country, city FROM person GROUP BY gender, country, city;
 SELECT count() AS total, math::sum(age), gender, country FROM person GROUP BY gender, country;
 
 -- Get the total number of records in a table
-SELECT count() as number_of_records from person GROUP ALL
+SELECT count() AS number_of_records FROM person GROUP ALL
 
 -- Select unique values from a nested array across an entire table
 SELECT array::group(tags) AS tags FROM article GROUP ALL;

--- a/app/templates/docs/integration/websocket/text.hbs
+++ b/app/templates/docs/integration/websocket/text.hbs
@@ -7,7 +7,7 @@
 <Layout::Text text-l text-f>
 	<h2>WebSocket (text protocol)</h2>
 	<p>The WebSocket protocol allows for easy bi-directional communication with SurrealDB. This allows you to maintain a single connection to run all your queries, but also opens up the possibility of Live Queries!</p>
-	<blockquote yellow text="Note">Live queries are still under development, though available soon. Checkout <Link @href="https://www.youtube.com/watch?v=zEaQBiNbkoU">this livestream</Link> to learn more about Live Queries.</blockquote>
+	<blockquote yellow text="Note">Live queries are still under development, though available soon. Checkout <Link @link="https://www.youtube.com/watch?v=zEaQBiNbkoU">this livestream</Link> to learn more about Live Queries.</blockquote>
 </Layout::Text>
 
 <Layout::Gap mini />


### PR DESCRIPTION
Some minor fixes

### `DEFINE FIELD`

Before
<img width="816" alt="image" src="https://github.com/surrealdb/www.surrealdb.com/assets/23435099/bdcaaad6-28b4-4f5a-92db-e570f1ab7bfa">

After
<img width="811" alt="image" src="https://github.com/surrealdb/www.surrealdb.com/assets/23435099/e5399038-392b-4743-b705-04e8feaf739c">

### `SELECT GROUP`

Before
<img width="619" alt="image" src="https://github.com/surrealdb/www.surrealdb.com/assets/23435099/25787eb3-92e3-4222-9030-981642577411">

After
<img width="593" alt="image" src="https://github.com/surrealdb/www.surrealdb.com/assets/23435099/b237577c-e410-45fc-be31-771e2d3067c5">


### Integration -> Websocket

Link corrected as external link to YouTube