### PR TITLE
fix: medium icon on homepage

### DIFF
--- a/app/components/footer/index.hbs
+++ b/app/components/footer/index.hbs
@@ -57,7 +57,7 @@
 						<Ascua::Tooltip @side="n" @show="hover" @hide="hover">
 							Join our Medium community
 						</Ascua::Tooltip>
-						<i class="fab fa-dev"></i>
+						<i class="fab fa-medium"></i>
 					</Link>
 					<Link @link={{url "stackoverflow"}}>
 						<Ascua::Tooltip @side="n" @show="hover" @hide="hover">


### PR DESCRIPTION
## Issue

Closes #227 

## Changes

Added the correct icon to the medium link. Change from `fa-dev` to `fa-medium`

 ## Screenshot

![Screenshot 2023-07-18 at 1 56 43 PM](https://github.com/surrealdb/www.surrealdb.com/assets/51878265/38a0872c-3e7b-4784-b92d-191875531076)

