### PR TITLE
Fix typo `paysing`

### DIFF
--- a/app/templates/docs/surrealql/functions/index.hbs
+++ b/app/templates/docs/surrealql/functions/index.hbs
@@ -81,7 +81,7 @@
 	<LinkTo @route="docs.surrealql.functions.sleep">
 		<Layout::Boxes::Item mini hover>
 			<h4>Sleep function</h4>
-			<p>Function for delaying or paysing the execution of a query</p>
+			<p>Function for delaying or pausing the execution of a query</p>
 		</Layout::Boxes::Item>
 	</LinkTo>
 	<LinkTo @route="docs.surrealql.functions.string">


### PR DESCRIPTION
Just a simple typo fix I found on the website while reading

You can see the typo [here](https://surrealdb.com/docs/surrealql/functions) in the `Sleep function` section, it says `paysing` instead of `pausing`