### PR TITLE
Fixed the Rust doc return type of deleting a specific record from a table

### DIFF
--- a/app/snippets/docs/integration/libraries/rust/delete.rust
+++ b/app/snippets/docs/integration/libraries/rust/delete.rust
@@ -1,4 +1,4 @@
 // Delete all records from a table
 let people: Vec<Person> = db.delete("person").await?;
 // Delete a specific record from a table
-let people: Vec<Person> = db.delete(("person", "h5wxrf2ewk8xjxosxtyc")).await?;
+let people: Option<Person> = db.delete(("person", "h5wxrf2ewk8xjxosxtyc")).await?;


### PR DESCRIPTION
Should be Option<T>, was Vec<T>, which would throw an error. The documentation is correct on [docs.rs](https://docs.rs/surrealdb/1.0.0-beta.9+20230402/surrealdb/struct.Surreal.html#method.delete)