### PR TITLE
WWW: Add focus for focusable elements

### DIFF
--- a/app/styles/links.scss
+++ b/app/styles/links.scss
@@ -10,6 +10,12 @@ a {
 		color:var(--hover-color);
 	}
 
+	&:focus {
+		outline: 2px solid #ea20e3 ; /* for non-webkit browsers */
+		outline: 5px auto #ea20e3 -webkit-focus-ring-color;
+		border-radius: 5px;
+	}
+
 	span + i {
 		padding-left:30px;
 	}


### PR DESCRIPTION
Links do not currently have focus styling which causes A11Y issues regarding keyboard navigations. 
<img width="965" alt="Screenshot 2023-09-13 at 12 07 42" src="https://github.com/surrealdb/www.surrealdb.com/assets/35943047/8af6c6f3-fa29-4966-932d-df84cdc3e07d">
