### PR TITLE
Docs: Fix: Add auth flag

### DIFF
--- a/app/templates/docs/installation/running/file.hbs
+++ b/app/templates/docs/installation/running/file.hbs
@@ -35,7 +35,7 @@
 	<p>After running the above command, you should see the SurrealDB server startup successfully.</p>
 
 	<Code @name="docs-installation-running-file-5.shell">
-		user@localhost % surreal start --user root --pass root --bind 0.0.0.0:8080 file:mydatabase.db
+		user@localhost % surreal start --auth --user root --pass root --bind 0.0.0.0:8080 file:mydatabase.db
 		2023-08-30T15:06:34.788739Z  INFO surreal::dbs: ✅🔒 Authentication is enabled 🔒✅
 		2023-08-30T15:06:34.788821Z  INFO surrealdb::kvs::ds: Starting kvs store in file:mydatabase.db
 		2023-08-30T15:06:34.788859Z  INFO surrealdb::kvs::ds: Started kvs store in file:mydatabase.db

--- a/app/templates/docs/installation/running/memory.hbs
+++ b/app/templates/docs/installation/running/memory.hbs
@@ -41,7 +41,7 @@
 	<p>After running the above command, you should see the SurrealDB server startup successfully.</p>
 
 	<Code @name="docs-installation-running-memory-5.shell">
-		user@localhost % surreal start --user root --pass root --bind 0.0.0.0:8080 memory
+		user@localhost % surreal start --auth --user root --pass root --bind 0.0.0.0:8080 memory
 		2023-08-30T15:06:34.788739Z  INFO surreal::dbs: ✅🔒 Authentication is enabled 🔒✅
 		2023-08-30T15:06:34.788821Z  INFO surrealdb::kvs::ds: Starting kvs store in memory
 		2023-08-30T15:06:34.788859Z  INFO surrealdb::kvs::ds: Started kvs store in memory

--- a/app/templates/docs/installation/running/tikv.hbs
+++ b/app/templates/docs/installation/running/tikv.hbs
@@ -62,7 +62,7 @@
 	<p>After running the above command, you should see the SurrealDB server startup successfully.</p>
 
 	<Code @name="docs-installation-running-tikv-7.shell">
-		user@localhost % surreal start --user root --pass root --bind 0.0.0.0:8080 tikv://127.0.0.1:2379
+		user@localhost % surreal start --auth --user root --pass root --bind 0.0.0.0:8080 tikv://127.0.0.1:2379
 		2023-08-30T15:06:34.788739Z  INFO surreal::dbs: ✅🔒 Authentication is enabled 🔒✅
 		2023-08-30T15:06:34.788821Z  INFO surrealdb::kvs::ds: Starting kvs store in tikv://127.0.0.1:2379
 		2023-08-30T15:06:34.788859Z  INFO surrealdb::kvs::ds: Started kvs store in tikv://127.0.0.1:2379


### PR DESCRIPTION
## Description

Hi there! While going through the guide, I noticed that running `surreal start --user root --pass root --bind 0.0.0.0:8080` didn't actually enable authentication as expected. It looks like the `--auth memory` flag is needed for that to work properly. I've made the necessary adjustments to the guide to reflect this. Hope this helps!

## Changes

- Added the `--auth` flag to the relevant code snippet in the guide in 3 files.
- Clarified that this flag is necessary for enabling in-memory authentication.

## Testing

I tested this locally to confirm that the updated command now enables authentication as intended.

Cheers,
Miguel Gargallo @miguelgargallo

May I be wrong @tobiemh, @jaimemh but is this possible?

Also I attached the log
[Log at 2023-09-15 1-52-08 PM.txt](https://github.com/surrealdb/www.surrealdb.com/files/12619585/Log.at.2023-09-15.1-52-08.PM.txt)
<img width="1680" alt="Screenshot 2023-09-15 at 1 39 13 PM" src="https://github.com/surrealdb/www.surrealdb.com/assets/5947268/075bdca6-84c3-4f43-98ad-7b0ac0a6ed1f">
<img width="1680" alt="Screenshot 2023-09-15 at 1 34 00 PM" src="https://github.com/surrealdb/www.surrealdb.com/assets/5947268/d80d97dc-4492-42a2-8d09-40aa6a8d23b4">
<img width="1680" alt="Screenshot 2023-09-15 at 1 33 05 PM" src="https://github.com/surrealdb/www.surrealdb.com/assets/5947268/9ec00b08-7551-4650-acea-8f6d475893f6">


