### PR TITLE
fix: typos

### DIFF
--- a/app/components/section/releases/index.js
+++ b/app/components/section/releases/index.js
@@ -400,7 +400,7 @@ export default class extends Component {
 							'Allow parameters in <code>LIMIT</code> and <code>START</code> clauses in <code>SELECT</code> statements',
 							'Add <code>parse::url::scheme()</code> function for parsing a url protocol',
 							'Add <code>time::format()</code> function for formatting of datetimes',
-							'Add support for <code>FETCH</code> cluases in SQL <code>RETURN</code> statements',
+							'Add support for <code>FETCH</code> clauses in SQL <code>RETURN</code> statements',
 							'Add <code>rand::uuid::v4()</code> and <code>rand::uuid::v7()</code> functions for creating different UUID types',
 							'Add Null Coalescing Operator and Ternary Conditional Operator',
 							'Enable current input to be retrieved in <code>ON DUPLICATE KEY UPDATE</code> clauses with <code>$input</code> parameter',

--- a/app/components/section/releases/v1-0-0-beta-10.hbs
+++ b/app/components/section/releases/v1-0-0-beta-10.hbs
@@ -116,7 +116,7 @@
 			Strict typing in <img inline src="/static/img/surrealql-text.svg" alt="SurrealQL" />
 		</h4>
 		<p>
-			<code>v1.0.0-beta.10</code> introduces a more strict and powerfull typing system.
+			<code>v1.0.0-beta.10</code> introduces a more strict and powerful typing system.
 			It makes things more simple to understand, and it goes a long way in preventing all kinds of weird bugs in your schemas!
 		</p>
 	</block>

--- a/app/snippets/docs/embedding/libraries/rust/cargo-features.bash
+++ b/app/snippets/docs/embedding/libraries/rust/cargo-features.bash
@@ -10,5 +10,5 @@ cargo add surrealdb --features kv-speedb
 # For FoundationDB cluster (FoundationDB must be installed and the appropriate version selected)
 cargo add surrealdb --features kv-fdb-7_1
 
-# For a TiKV cluster (TiKV and other dependancies must be installed)
+# For a TiKV cluster (TiKV and other dependencies must be installed)
 cargo add surrealdb --features kv-tikv

--- a/app/snippets/docs/surrealql/statements/define/namespace/namespace.surql
+++ b/app/snippets/docs/surrealql/statements/define/namespace/namespace.surql
@@ -1,2 +1,2 @@
--- Namepace for Abcum Ltd.
+-- Namespace for Abcum Ltd.
 DEFINE NAMESPACE abcum;

--- a/app/snippets/docs/surrealql/statements/for/syntax.typescript
+++ b/app/snippets/docs/surrealql/statements/for/syntax.typescript
@@ -1,1 +1,1 @@
-FOR @item IN @iteratable @block
+FOR @item IN @iterable @block

--- a/app/templates/docs/cli/backup.hbs
+++ b/app/templates/docs/cli/backup.hbs
@@ -6,7 +6,7 @@
 
 <Layout::Text text-l text-f>
 	<h2>Backup command</h2>
-	<p>The Backup command backs up data into or from an exisiting database.</p>
+	<p>The Backup command backs up data into or from an existing database.</p>
 	<blockquote yellow text="Before you start">Make sure you’ve <Link @link="docs.installation">installed SurrealDB</Link> — it should only take a second!</blockquote>
 </Layout::Text>
 

--- a/app/templates/docs/cli/index.hbs
+++ b/app/templates/docs/cli/index.hbs
@@ -32,7 +32,7 @@
 	<LinkTo @route="docs.cli.backup">
 		<Layout::Boxes::Item mini hover>
 			<h4>Backup command</h4>
-			<p>Backup data to or from an exisiting database</p>
+			<p>Backup data to or from an existing database</p>
 		</Layout::Boxes::Item>
 	</LinkTo>
 	<LinkTo @route="docs.cli.version">

--- a/app/templates/docs/installation/upgrading/beta9-to-beta10.hbs
+++ b/app/templates/docs/installation/upgrading/beta9-to-beta10.hbs
@@ -93,7 +93,7 @@
 	<p>We have introduced capabilities in <code>v1.0.0-beta.10</code>. They allow you to allow or deny certain aspects of SurrealDB.</p>
 	<p>In our effort to deliver a security-first and water-tight database, all capabilities are disabled by default. This means that by default, you are not able to use any methods, embedded scripting functions, make outbound network calls, or access the database anonymously.</p>
 	<p>
-		You can easily enable all these capabilties again with the <code>--allow-all</code> flag, or choose which capabilities to enable yourself. <br />
+		You can easily enable all these capabilities again with the <code>--allow-all</code> flag, or choose which capabilities to enable yourself. <br />
 		This is further documented in the <Link @link="docs.security.capabilities">Capabilities</Link> documentation.
 	</p>
 

--- a/app/templates/docs/integration/websocket/text.hbs
+++ b/app/templates/docs/integration/websocket/text.hbs
@@ -83,7 +83,7 @@
 						<code>unset</code> <code>[ name ]</code>
 					</a>
 				</td>
-				<td>Remove a variable from the currect connection</td>
+				<td>Remove a variable from the current connection</td>
 			</tr>
 			<tr>
 				<td>

--- a/app/templates/docs/surrealql/demo.hbs
+++ b/app/templates/docs/surrealql/demo.hbs
@@ -34,7 +34,7 @@
 
 <Layout::Gap mini />
 
-	<h4>Dowload and import</h4>
+	<h4>Download and import</h4>
 	<p>
 <Link @link="https://drive.google.com/uc?id=1AlSMBJrncEuqOtbbEXLqtenUb0Z5BjlD&export=download"> Download the dataset here</Link>, then <Link @link="docs.cli.start">start the server</Link> and use the <Link  @link="docs.cli.import"> import command </Link> to add the dataset from your "Downloads" folder. Please be aware that the import process might take a few seconds.
 	</p>

--- a/app/templates/docs/surrealql/functions/array.hbs
+++ b/app/templates/docs/surrealql/functions/array.hbs
@@ -983,7 +983,7 @@
 				[ true, true, true, false ]
 			</Code>
 		</codes>
-		<p> If one of the arrray is empty, the first array is returned.</p>
+		<p> If one of the array is empty, the first array is returned.</p>
         <codes vertical>
 			<Code @name="docs-surrealql-functions-array-logical_or-error-input.surql">
 				RETURN array::logical_or([0, 1], []);
@@ -1015,7 +1015,7 @@
 				[ false, true, true, false ]
 			</Code>
 		</codes>
-		<p>If one of the arrray is empty, the first array is returned.</p>
+		<p>If one of the array is empty, the first array is returned.</p>
         <codes vertical>
 			<Code @name="docs-surrealql-functions-array-logical_xor-error-input.surql">
 				RETURN array::logical_xor([0, 1], [])

--- a/app/templates/docs/surrealql/functions/string.hbs
+++ b/app/templates/docs/surrealql/functions/string.hbs
@@ -35,7 +35,7 @@
 						<code>string::contains()</code>
 					</a>
 				</td>
-				<td>Check wether a string contains another string</td>
+				<td>Check whether a string contains another string</td>
 			</tr>
 			<tr>
 				<td>
@@ -83,7 +83,7 @@
 						<code>string::replace()</code>
 					</a>
 				</td>
-				<td>Replaces an occurence of a string with another string</td>
+				<td>Replaces an occurrence of a string with another string</td>
 			</tr>
 			<tr>
 				<td>
@@ -286,7 +286,7 @@
 
 	<Layout::Text text-l text-f>
 		<h3><code>string::contains</code></h3>
-		<p>The <code>string::contains</code> function checks wether a string contains another string.</p>
+		<p>The <code>string::contains</code> function checks whether a string contains another string.</p>
 		<Code @name="docs-surrealql-functions-string-contains.surql" text="API Definition">
 			string::contains(string, string) -> bool
 		</Code>
@@ -424,7 +424,7 @@
 
 	<Layout::Text text-l text-f>
 		<h3><code>string::replace</code></h3>
-		<p>The <code>string::replace</code> function replaces an occurence of a string with another string.</p>
+		<p>The <code>string::replace</code> function replaces an occurrence of a string with another string.</p>
 		<Code @name="docs-surrealql-functions-string-replace.surql" text="API Definition">
 			string::replace(string, string, string) -> string
 		</Code>

--- a/app/templates/docs/surrealql/operators.hbs
+++ b/app/templates/docs/surrealql/operators.hbs
@@ -1274,7 +1274,7 @@
 
 	<Layout::Text text-l text-f>
 		<h3><code>INTERSECTS</code></h3>
-		<p>Check whether a geometry value intersects annother geometry value.</p>
+		<p>Check whether a geometry value intersects another geometry value.</p>
 		<codes vertical>
 			<Code @name="docs-surrealql-operators-intersects-input.surql">
 				SELECT * FROM {

--- a/app/templates/docs/surrealql/statements/delete.hbs
+++ b/app/templates/docs/surrealql/statements/delete.hbs
@@ -53,7 +53,7 @@
 		<Code @name="docs-statements-relate-example.surql">
 			RELATE person:tobie->bought->product:iphone;
 	</Code>
-	<Code @name="docs-statements-delet-example.txt">
+	<Code @name="docs-statements-delete-example.txt">
 			[
 				{
 					"id": "bought:ctwsll49k37a7rmqz9rr",

--- a/app/templates/docs/surrealql/statements/relate.hbs
+++ b/app/templates/docs/surrealql/statements/relate.hbs
@@ -163,7 +163,7 @@
 		<Code @name="docs-statements-relate-example.surql">
 			RELATE person:tobie->bought->product:iphone;
 	</Code>
-	<Code @name="docs-statements-delet-example.txt">
+	<Code @name="docs-statements-delete-example.txt">
 			[
 				{
 					"id": "bought:ctwsll49k37a7rmqz9rr",

--- a/app/templates/docs/surrealql/statements/select.hbs
+++ b/app/templates/docs/surrealql/statements/select.hbs
@@ -7,7 +7,7 @@
 
 <Layout::Text text-l text-f>
     <h2><code>SELECT</code> statement</h2>
-	<p>The SELECT statement can be used for selecting and querying data in a database. Each SELECT statement supports selecting from multiple targets, which can include tables, records, edges, subqueries, paramaters, arrays, objects, and other values.</p>
+	<p>The SELECT statement can be used for selecting and querying data in a database. Each SELECT statement supports selecting from multiple targets, which can include tables, records, edges, subqueries, parameters, arrays, objects, and other values.</p>
 </Layout::Text>
 
 <Layout::Gap mini />

--- a/app/templates/docs/surrealql/statements/show.hbs
+++ b/app/templates/docs/surrealql/statements/show.hbs
@@ -24,7 +24,7 @@
 	<h3>Example usage</h3>
 
 	<h4>Basic usage</h4>
-	<p>The following expression shows usugae of Show statment.</p>
+	<p>The following expression shows usugae of Show statement.</p>
 	<Code @name="docs/surrealql/statements/show/simple.surql" />
 </Layout::Text>
 

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -33,7 +33,7 @@
 	<Layout::Boxes::Item text-l team @title="Naiyarah Hussain" @image="/static/img/team/naiyarah.jpg" @text="Developer Relations Manager" />
 	<Layout::Boxes::Item text-l team @title="Farhan Khan" @image="/static/img/team/farhan.jpg" @text="Senior Software Engineer" />
 	<Layout::Boxes::Item text-l team @title="Mees Delzenne" @image="/static/img/team/mees.jpg" @text="Software Engineer" />
-	<Layout::Boxes::Item text-l team @title="Obinna Ekwuno" @image="/static/img/team/obinna.jpg" @text="Developer Experience Engineeer" />
+	<Layout::Boxes::Item text-l team @title="Obinna Ekwuno" @image="/static/img/team/obinna.jpg" @text="Developer Experience Engineer" />
 	<Layout::Boxes::Item text-l team @title="Maxwell Flitton" @image="/static/img/team/maxwell.jpg" @text="Senior Software Engineer" />
 	<Layout::Boxes::Item text-l team @title="Ned Rudkins-Stow" @image="/static/img/team/ned.jpg" @text="Experiences Coordinator" />
 	<Layout::Boxes::Item text-l team @title="Meriel Cunningham" @image="/static/img/team/meriel.jpg" @text="Experiences Coordinator" />

--- a/temp.md
+++ b/temp.md
@@ -19,4 +19,4 @@ Add functionality to generate different Record IDs: CREATE person:rand(), person
 Add SurrealQL functions to JavaScript runtime
 Add CLI option to disable server banner
 Add current INSERT value as parameter value to ON DUPLICATE KEY clause (accessed using $input)
-Add support for `FETCH` cluases in SQL `RETURN` statements
+Add support for `FETCH` clauses in SQL `RETURN` statements


### PR DESCRIPTION
Typos were found using [crate-ci/typos](https://github.com/crate-ci/typos); however, there are too many false flags to be reasonably integrated into the site.