### PR TITLE
update nodejs snippets & examples to reflect updated ns & db config

### DIFF
--- a/app/snippets/docs/integration/libraries/nodejs/basic.js
+++ b/app/snippets/docs/integration/libraries/nodejs/basic.js
@@ -20,7 +20,7 @@ async function main() {
 		});
 
 		// Select a specific namespace / database
-		await db.use({ namespace: 'test', database: 'test' });
+		await db.use({ ns: 'test', db: 'test' });
 
 		// Create a new person with a random id
 		let created = await db.create('person', {

--- a/app/templates/docs/integration/sdks/nodejs.hbs
+++ b/app/templates/docs/integration/sdks/nodejs.hbs
@@ -82,7 +82,7 @@
 			<tr>
 				<td>
 					<a href="#use">
-						<Ascua::Prism::Inline @language="js" @code="async db.use({ namespace, database })" />
+						<Ascua::Prism::Inline @language="js" @code="async db.use({ ns, db })" />
 					</a>
 				</td>
 				<td>Switch to a specific namespace and database</td>
@@ -298,8 +298,8 @@
 <Layout::Group {{waypoint "use"}}>
 
 	<Layout::Text text-l text-f>
-		<h3><Ascua::Prism::Inline @language="ts" @code="db.use({ namespace, database })" /></h3>
-		<p>Switch to a specific namespace and database. If only the <code>namespace</code> or <code>database</code> property is specified, the current connection details will be used to fill the other property.</p>
+		<h3><Ascua::Prism::Inline @language="ts" @code="db.use({ ns, db })" /></h3>
+		<p>Switch to a specific namespace and database. If only the <code>ns</code> or <code>db</code> property is specified, the current connection details will be used to fill the other property.</p>
 		<Layout::Table>
 			<table>
 				<thead>
@@ -311,7 +311,7 @@
 				<tbody>
 					<tr>
 						<td>
-							<code>namespace</code>
+							<code>ns</code>
 							<l yellow r>Initially required</l>
 						</td>
 						<td>
@@ -320,7 +320,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code>database</code>
+							<code>db</code>
 							<l yellow r>Initially required</l>
 						</td>
 						<td>
@@ -331,7 +331,7 @@
 			</table>
 		</Layout::Table>
 		<Code @name="docs-integration-libraries-nodejs-use.js">
-			await db.use({ namespace: 'surrealdb', database: 'docs' });
+			await db.use({ ns: 'surrealdb', db: 'docs' });
 		</Code>
 	</Layout::Text>
 


### PR DESCRIPTION
Updated the snippets and examples for [**Docs>SDK>Node.js**] to reflect the updated config for setting namespace & database.

## Old Method
```js
db.use({database:"dev", namespace:"dev"})
```

## New Method
```js
db.use({db:"dev", ns:"dev"})
```